### PR TITLE
Fixed Your Courses study period selection crash bug

### DIFF
--- a/client/student-attendence-system/src/App.js
+++ b/client/student-attendence-system/src/App.js
@@ -11,6 +11,7 @@ import Login from "./pages/Login";
 
 import StudentHome from "./pages/StudentHome";
 import Dashboard from "./pages/Dashboard";
+import InvalidComponent from "./components/pc/InvalidComponent";
 function RequireAuth({ children }) {
   const authed = localStorage.getItem("login");
 
@@ -27,7 +28,8 @@ function App() {
       <Router>
         {/* <Navigation /> */}
         <Routes>
-          <Route path="/" element={<Login />} />
+          <Route path="*" element={<InvalidComponent/>}/>
+          <Route path="/" element={<Navigate replace to="/Login"/>} />
           <Route path="/Login" element={<Login />} />
           <Route
             path="/Dashboard/*"
@@ -45,7 +47,6 @@ function App() {
               </RequireAuth>
             }
           />
-          <Route path="/Login" element={<Login />} />
         </Routes>
       </Router>
     </div>

--- a/client/student-attendence-system/src/components/pc/Routes.js
+++ b/client/student-attendence-system/src/components/pc/Routes.js
@@ -15,7 +15,7 @@ export default function MainRoutes (props){
             <Route path="*" element={<><Header pageName={"404"}/><div className={sty.rightDesc}><InvalidComponent/></div></>}/>
             <Route path="/" element={<Navigate replace to="Courses"/>}/>
             <Route path="Courses" element={<><Header pageName={"Your Course"}/><div className={sty.rightDesc}><YourCourse courseList={lecturer.courses}/></div></>}/>
-            <Route path="CoursesDetail" element={<><Header pageName={"Course"}/><div className={sty.rightDesc}><CourseDetails courseName={lecturer.courseName} staffID={lecturer.staffID}></CourseDetails></div></>}></Route>
+            <Route path="CoursesDetail" element={<><Header pageName={"Course Detail"}/><div className={sty.rightDesc}><CourseDetails courseName={lecturer.courseName} staffID={lecturer.staffID}></CourseDetails></div></>}></Route>
         </Route>
         </Routes>
     )

--- a/client/student-attendence-system/src/components/pc/YourCourse.js
+++ b/client/student-attendence-system/src/components/pc/YourCourse.js
@@ -24,7 +24,7 @@ export default function YourCourse ({courseList, forwardFunction}, props) {
                 </div>
                 <div className={sty.formBody}>
                         <Form.Select onChange={(e) => classandStudyPeriod(e.target.value)}>
-                                <option key = "default" value="SP0" selected>Select A Course</option>
+                                <option key = "default" value="SP0" selected disabled>Select A Course</option>
                                 {avalibleStudyPeriod.map((studyPeriod) => (
                                         <option key={`SP${studyPeriod}`} value={`SP${studyPeriod}`}>Study Period {studyPeriod}</option>
                                 ))}


### PR DESCRIPTION
Fixed a bug that would cause the application to crash if the following steps were completed:

- Open 'Your Courses' page
- Select a study period from dropdown box
- Select first option from dropdown ('Select A Course')
- Application would crash as no courses exist for this menu option

Have fixed this by disabling that dropdown option from being clickable.